### PR TITLE
Allow user to search complete schedule list on specific course page

### DIFF
--- a/src/adapters/CartAdapter/index.js
+++ b/src/adapters/CartAdapter/index.js
@@ -111,7 +111,7 @@ class CartAdapter {
           {
             filterKeys: ["schedule-slug"],
             originalFilterKeys: ["schedule-slug"],
-            hightlight: false,
+            highlight: false,
             elements: [],
             values: defaultFilter,
           },

--- a/src/components/ClassScheduleList/index.js
+++ b/src/components/ClassScheduleList/index.js
@@ -53,7 +53,7 @@ class ClassScheduleList {
         this.classScheduleInstance.filtersData.push({
           filterKeys: ["course-slug"],
           originalFilterKeys: ["course-slug"],
-          hightlight: false,
+          highlight: false,
           elements: [],
           values: defaultFilter,
         });

--- a/src/components/ClassScheduleList/index.js
+++ b/src/components/ClassScheduleList/index.js
@@ -14,6 +14,7 @@ class ClassScheduleList {
     this.options = { ...DEFAULT_OPTIONS, ...options };
     this.selectors = {
       cartActionWrapper: ".class-schedule_add-wrapper",
+      clearDefaultFilterBtn: "[data-class-schedule-list-clear-default]",
     };
 
     this.defaultCourse = elementRef.dataset.defaultCourse;
@@ -32,11 +33,11 @@ class ClassScheduleList {
     window.fsAttributes.push([
       "cmsfilter",
       (filterInstances) => {
-        const classScheduleInstance = filterInstances.find(
+        this.classScheduleInstance = filterInstances.find(
           (instance) => instance.form.dataset.name == "schedule-filter"
         );
 
-        if (classScheduleInstance == null) {
+        if (this.classScheduleInstance == null) {
           return;
         }
 
@@ -46,17 +47,15 @@ class ClassScheduleList {
           defaultFilter.add(filter);
         });
 
-        classScheduleInstance.filtersData = [
-          {
-            filterKeys: ["course-slug"],
-            originalFilterKeys: ["course-slug"],
-            hightlight: false,
-            elements: [],
-            values: defaultFilter,
-          },
-        ];
+        this.classScheduleInstance.filtersData.push({
+          filterKeys: ["course-slug"],
+          originalFilterKeys: ["course-slug"],
+          hightlight: false,
+          elements: [],
+          values: defaultFilter,
+        });
 
-        classScheduleInstance.applyFilters();
+        this.classScheduleInstance.applyFilters();
       },
     ]);
   }
@@ -67,10 +66,27 @@ class ClassScheduleList {
     window.addEventListener("cart-updated", () => {
       this._refreshDisplay();
     });
+
+    const clearDefaultFilterBtn = document.querySelector(
+      this.selectors.clearDefaultFilterBtn
+    );
+
+    if (clearDefaultFilterBtn) {
+      clearDefaultFilterBtn.addEventListener("click", () => {
+        this._clearDefaultFilter();
+      });
+    }
   }
 
   _refreshDisplay() {
     this.addScheduleButtons.forEach((button) => button.refreshDisplay());
+  }
+
+  _clearDefaultFilter() {
+    this.classScheduleInstance.filtersData =
+      this.classScheduleInstance.filtersData.filter(
+        (filter) => filter.filterKeys[0] != "course-slug"
+      );
   }
 
   _setupAddScheduleButton() {

--- a/src/components/CourseSuggestSection/index.js
+++ b/src/components/CourseSuggestSection/index.js
@@ -67,7 +67,7 @@ class CourseSuggestSection {
           {
             filterKeys: ["level-slug"],
             originalFilterKeys: ["level-slug"],
-            hightlight: false,
+            highlight: false,
             elements: [],
             values: filter,
           },

--- a/src/components/MyClassCart/index.js
+++ b/src/components/MyClassCart/index.js
@@ -80,7 +80,7 @@ class MyClassCart {
           {
             filterKeys: ["schedule-slug"],
             originalFilterKeys: ["schedule-slug"],
-            hightlight: false,
+            highlight: false,
             elements: [],
             values: defaultFilter,
           },


### PR DESCRIPTION
## What happened 📌

Fix schedule searching on the course-specific page from users can search only the schedule belonging to the course to search for any courses.

## Proof Of Work 📸

Users can search for any schedule on the course-specific page.

https://user-images.githubusercontent.com/14077479/236774106-b2186423-9f6a-4d74-aeb5-1b6fb87cbec9.mov


