### PR TITLE
As an admin, I can fill in Event Topics as rich-text content

### DIFF
--- a/src/components/AccordionsComponent/index.js
+++ b/src/components/AccordionsComponent/index.js
@@ -1,0 +1,64 @@
+/**
+ * Module Name: AccordionsComponent
+ *
+ */
+class AccordionsComponent {
+  constructor(elementRef) {
+    this.elementRef = elementRef;
+    this.component = this._convertedComponentFromRichText();
+
+    elementRef.replaceWith(this.component);
+  }
+
+  // Private
+
+  _convertedComponentFromRichText() {
+    const component = this._createElement("div", "accordions");
+
+    const headers = this.elementRef.querySelectorAll("h1, h2, h3, h4, h5, h6");
+
+    headers.forEach((header) => {
+      const accordion = this._createElement("div", "accordion_component");
+
+      const headerText = header.textContent.trim();
+      const accordionHeader = this._createElement("div", "accordion_header");
+
+      const headerTitle = this._createElement("div", "accordion_header-title");
+      headerTitle.textContent = headerText;
+      accordionHeader.appendChild(headerTitle);
+
+      if (headerText.toLowerCase().startsWith("[bonus]")) {
+        headerTitle.textContent = headerText.replace(/^\[bonus\]\s*/i, "");
+
+        const bonusSpan = this._createElement("span", "bonus_span");
+        bonusSpan.textContent = "Bonus";
+        accordionHeader.appendChild(bonusSpan);
+      }
+
+      const accordionIcon = this._createElement("div", "accordion_icon");
+      accordionHeader.appendChild(accordionIcon);
+
+      const accordionContent = this._createElement("div", "accordion_content");
+
+      let next = header.nextElementSibling;
+      while (next && !/^H\d$/.test(next.tagName)) {
+        accordionContent.appendChild(next);
+        next = header.nextElementSibling;
+      }
+
+      accordion.appendChild(accordionHeader);
+      accordion.appendChild(accordionContent);
+
+      component.appendChild(accordion);
+    });
+
+    return component;
+  }
+
+  _createElement(tag, className) {
+    const element = document.createElement(tag);
+    element.classList.add(className);
+
+    return element;
+  }
+}

--- a/src/components/EventDatesComponent/index.js
+++ b/src/components/EventDatesComponent/index.js
@@ -37,12 +37,6 @@ class EventDatesComponent {
           const bonusSpan = this._createElement("span", "bonus_span");
           bonusSpan.textContent = "Bonus";
           headerDiv.appendChild(bonusSpan);
-
-          let next = header.nextElementSibling;
-          while (next && !/^H1$/.test(next.tagName)) {
-            currentContainer.appendChild(next);
-            next = header.nextElementSibling;
-          }
         }
 
         headerDiv.appendChild(document.createTextNode(headerText));


### PR DESCRIPTION
[Link to ticket](https://www.notion.so/criclabs/As-an-admin-I-can-fill-in-Event-Topics-as-rich-text-content-bd7554aeabc0415aa91ede6110a6332f?pvs=4)

## What happened 📌

- Created `AccordionsComponent` to be used in _Course Details_ and _Event Details_ to convert rich-text to Course components and Event topics accordingly.
- Removed iterating next elements in `EventDatesComponent` when it's the bonus section. So, bonus sections should now work like other sections.

## Insight 🔍

For references (Current MS Website):
- [MS - Course](https://www.mindstretcher.com/courses/primary-3-english)
- [MS - Event](https://www.mindstretcher.com/events/p3-gep-screening-prep-bootcamp)

I did make some refactoring on Webflow for Accordion components where `accordion_content` wasn't wrapped with left turquoise border, but only list items were wrapped around.

## Proof Of Work 📸

- [Webflow - Course](https://mind-stretcher.webflow.io/courses/primary-3-english)