### PR TITLE
Fix See More and Next button not showing when its container is scrollable

### DIFF
--- a/src/components/EventDatesComponent/index.js
+++ b/src/components/EventDatesComponent/index.js
@@ -6,9 +6,9 @@ class EventDatesComponent {
   constructor(elementRef) {
     this.elementRef = elementRef;
     this.component = this._convertedComponentFromRichText();
-    this._addSeeMoreAndNextButtonIfNeeded();
-
     elementRef.replaceWith(this.component);
+
+    this._addSeeMoreAndNextButtonIfNeeded();
   }
 
   // Private


### PR DESCRIPTION
[Link to ticket](https://www.notion.so/criclabs/As-an-admin-I-can-fill-in-Event-Dates-as-rich-text-content-8e0d79a40d8344938e46cb2124c6093d?pvs=4)

## What happened 📌

Swapped the lines a bit to replace with the converted component **before** adding See More and Next.

## Insight 🔍

If the component hasn't been replaced before, the `clientWidth` and `scrollWidth` would remain 0 and we couldn't tell if it goes beyond its bounding box or not.

## Proof Of Work 📸

<img width="1404" alt="image" src="https://github.com/criclabs-co/mind-stretcher-web/assets/13864215/ab9de639-713b-4f35-a5e7-e86f0b9a6cf5">

_(I added the Class in-line to test the result)_